### PR TITLE
Add convex hull fill render style to NPC Indicator plugin

### DIFF
--- a/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -205,6 +205,13 @@ public class NpcSceneOverlay extends Overlay
 					graphics.draw(objectClickbox);
 				}
 				break;
+			case FILL:
+				final Shape actorHull = actor.getConvexHull();
+				if (actorHull != null)
+				{
+					OverlayUtil.renderFilledPolygon(graphics, actorConvexHull, color);
+				}
+				break;
 			case THIN_OUTLINE:
 				modelOutliner.drawOutline(actor, 1, color);
 				break;

--- a/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
+++ b/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/RenderStyle.java
@@ -30,6 +30,7 @@ public enum RenderStyle
 	TILE,
 	THIN_TILE,
 	HULL,
+	FILL,
 	SOUTH_WEST_TILE,
 	THIN_OUTLINE,
 	OUTLINE,


### PR DESCRIPTION
Add fill mode render style to the NPC Indicator plugin. Will fill the selected NPC's convex hull with the specified color.