### PR TITLE
npc-highlight: Fix variable name typo in NpcSceneOverlay

### DIFF
--- a/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/npchighlight/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -209,7 +209,7 @@ public class NpcSceneOverlay extends Overlay
 				final Shape actorHull = actor.getConvexHull();
 				if (actorHull != null)
 				{
-					OverlayUtil.renderFilledPolygon(graphics, actorConvexHull, color);
+					OverlayUtil.renderFilledPolygon(graphics, actorHull, color);
 				}
 				break;
 			case THIN_OUTLINE:


### PR DESCRIPTION
Rename `actorConvexHull` -> `actorHull`